### PR TITLE
fix: mode shortcuts use event.code and mic toggle no longer changes mode

### DIFF
--- a/src/__tests__/content-helpers.test.ts
+++ b/src/__tests__/content-helpers.test.ts
@@ -146,7 +146,8 @@ describe("content and popup helpers", () => {
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "2",
+        key: "@",
+        code: "Digit2",
         repeat: false,
       } as KeyboardEvent),
     ).toBe(MODES.autoOff);
@@ -157,7 +158,8 @@ describe("content and popup helpers", () => {
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "2",
+        key: "@",
+        code: "Digit2",
         repeat: true,
       } as KeyboardEvent),
     ).toBeNull();

--- a/src/__tests__/content-helpers.test.ts
+++ b/src/__tests__/content-helpers.test.ts
@@ -166,7 +166,6 @@ describe("content and popup helpers", () => {
 
     expect(
       shouldTriggerShortcutKeyDown({
-        isListening: true,
         mode: MODES.autoOff,
         pttKeyHeld: false,
         shortcut: "Ctrl+Shift+M",
@@ -183,7 +182,6 @@ describe("content and popup helpers", () => {
 
     expect(
       shouldTriggerShortcutKeyUp({
-        isListening: true,
         mode: MODES.pushToTalk,
         pttKeyHeld: true,
         shortcut: "Ctrl+Shift+M",

--- a/src/__tests__/shortcut.test.ts
+++ b/src/__tests__/shortcut.test.ts
@@ -44,6 +44,7 @@ describe("shortcut utilities", () => {
           altKey: false,
           metaKey: false,
           key: "m",
+          code: "KeyM",
           repeat: true,
         },
         mode: MODES.autoOff,
@@ -53,14 +54,15 @@ describe("shortcut utilities", () => {
     ).toBe(false);
   });
 
-  it("maps fixed mode shortcuts to the correct modes", () => {
+  it("maps fixed mode shortcuts to the correct modes (using event.code)", () => {
     expect(
       getFixedModeShortcutTarget({
         ctrlKey: true,
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "0",
+        key: ")",
+        code: "Digit0",
         repeat: false,
       }),
     ).toBe(MODES.off);
@@ -70,7 +72,8 @@ describe("shortcut utilities", () => {
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "1",
+        key: "!",
+        code: "Digit1",
         repeat: false,
       }),
     ).toBe(MODES.auto);
@@ -80,7 +83,8 @@ describe("shortcut utilities", () => {
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "2",
+        key: "@",
+        code: "Digit2",
         repeat: false,
       }),
     ).toBe(MODES.autoOff);
@@ -90,7 +94,8 @@ describe("shortcut utilities", () => {
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "3",
+        key: "#",
+        code: "Digit3",
         repeat: false,
       }),
     ).toBe(MODES.pushToTalk);
@@ -103,7 +108,8 @@ describe("shortcut utilities", () => {
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "4",
+        key: "$",
+        code: "Digit4",
         repeat: false,
       }),
     ).toBeNull();
@@ -116,13 +122,14 @@ describe("shortcut utilities", () => {
         shiftKey: true,
         altKey: false,
         metaKey: false,
-        key: "1",
+        key: "!",
+        code: "Digit1",
         repeat: true,
       }),
     ).toBeNull();
   });
 
-  it("does not trigger fixed mode shortcuts when modifiers do not match", () => {
+  it("does not trigger fixed mode shortcuts when Shift is missing", () => {
     expect(
       getFixedModeShortcutTarget({
         ctrlKey: true,
@@ -130,6 +137,21 @@ describe("shortcut utilities", () => {
         altKey: false,
         metaKey: false,
         key: "0",
+        code: "Digit0",
+        repeat: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not trigger fixed mode shortcuts when Ctrl is missing", () => {
+    expect(
+      getFixedModeShortcutTarget({
+        ctrlKey: false,
+        shiftKey: true,
+        altKey: false,
+        metaKey: false,
+        key: "!",
+        code: "Digit1",
         repeat: false,
       }),
     ).toBeNull();
@@ -145,6 +167,7 @@ describe("shortcut utilities", () => {
           altKey: false,
           metaKey: false,
           key: "m",
+          code: "KeyM",
           repeat: false,
         },
         mode: MODES.autoOff,
@@ -164,6 +187,7 @@ describe("shortcut utilities", () => {
           altKey: false,
           metaKey: false,
           key: "m",
+          code: "KeyM",
           repeat: false,
         },
         mode: MODES.auto,
@@ -183,6 +207,7 @@ describe("shortcut utilities", () => {
           altKey: true,
           metaKey: false,
           key: "u",
+          code: "KeyU",
           repeat: false,
         },
         mode: MODES.autoOff,
@@ -238,6 +263,7 @@ describe("shortcut utilities", () => {
           altKey: false,
           metaKey: false,
           key: "m",
+          code: "KeyM",
           repeat: false,
         },
         mode: MODES.pushToTalk,

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -172,7 +172,6 @@ function handleShortcutKeyDown(e: KeyboardEvent) {
 
   if (
     !shouldTriggerShortcutKeyDown({
-      isListening,
       event: e,
       mode: selectedMode,
       pttKeyHeld,
@@ -181,8 +180,6 @@ function handleShortcutKeyDown(e: KeyboardEvent) {
   ) {
     return;
   }
-
-  consumeShortcutEvent(e);
 
   // If mode is Off, ignore mic-toggle shortcut — use mode shortcuts (Ctrl+Shift+0-3) instead
   if (!isModeActive(selectedMode)) {
@@ -193,6 +190,8 @@ function handleShortcutKeyDown(e: KeyboardEvent) {
   if (!isListening) {
     return;
   }
+
+  consumeShortcutEvent(e);
 
   if (shouldUsePushToTalkHold(selectedMode)) {
     pttKeyHeld = true;
@@ -214,7 +213,6 @@ function handleShortcutKeyUp(e: KeyboardEvent) {
   if (!shouldUsePushToTalkHold(selectedMode)) return;
   if (
     !shouldTriggerShortcutKeyUp({
-      isListening,
       event: e,
       mode: selectedMode,
       pttKeyHeld,

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -184,13 +184,13 @@ function handleShortcutKeyDown(e: KeyboardEvent) {
 
   consumeShortcutEvent(e);
 
-  // If mode is Off or not listening, re-enable the last active mode
-  if (!isModeActive(selectedMode) || !isListening) {
-    const modeToRestore = lastActiveMode;
-    selectedMode = modeToRestore;
-    void chrome.storage.local.set({ [STORAGE_KEYS.mode]: modeToRestore });
-    log(`ショートカットでモードを復元: ${modeToRestore}`);
-    scheduleStartListening();
+  // If mode is Off, ignore mic-toggle shortcut — use mode shortcuts (Ctrl+Shift+0-3) instead
+  if (!isModeActive(selectedMode)) {
+    return;
+  }
+
+  // If listening hasn't started yet, wait for it
+  if (!isListening) {
     return;
   }
 

--- a/src/content/shortcut-controller.ts
+++ b/src/content/shortcut-controller.ts
@@ -14,7 +14,6 @@ export function consumeShortcutEvent(e: KeyboardEvent) {
 }
 
 export function shouldTriggerShortcutKeyDown(args: {
-  isListening: boolean;
   mode: ModeId;
   pttKeyHeld: boolean;
   shortcut: string;
@@ -34,7 +33,6 @@ export function getModeSwitchShortcutTarget(event: KeyboardEvent) {
 }
 
 export function shouldTriggerShortcutKeyUp(args: {
-  isListening: boolean;
   mode: ModeId;
   pttKeyHeld: boolean;
   shortcut: string;

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -13,12 +13,12 @@ type ShortcutKeyDownEvent = ShortcutMatchEvent & Pick<KeyboardEvent, "code" | "r
  * because Shift changes the key value on many layouts
  * (e.g. Shift+1 = "!" on US, Shift+0 = ")" etc.).
  */
-const FIXED_MODE_SHORTCUTS: ReadonlyArray<{ code: string; mode: ModeId }> = [
+const FIXED_MODE_SHORTCUTS = [
   { code: "Digit0", mode: MODES.off },
   { code: "Digit1", mode: MODES.auto },
   { code: "Digit2", mode: MODES.autoOff },
   { code: "Digit3", mode: MODES.pushToTalk },
-];
+] as const;
 
 export function parseShortcut(shortcut: string) {
   const parts = shortcut.toLowerCase().split("+");

--- a/src/shortcut.ts
+++ b/src/shortcut.ts
@@ -6,14 +6,19 @@ type ShortcutMatchEvent = Pick<
   "altKey" | "ctrlKey" | "key" | "metaKey" | "shiftKey"
 >;
 
-type ShortcutKeyDownEvent = ShortcutMatchEvent & Pick<KeyboardEvent, "repeat">;
+type ShortcutKeyDownEvent = ShortcutMatchEvent & Pick<KeyboardEvent, "code" | "repeat">;
 
-const FIXED_MODE_SHORTCUTS = [
-  { shortcut: "Ctrl+Shift+0", mode: MODES.off },
-  { shortcut: "Ctrl+Shift+1", mode: MODES.auto },
-  { shortcut: "Ctrl+Shift+2", mode: MODES.autoOff },
-  { shortcut: "Ctrl+Shift+3", mode: MODES.pushToTalk },
-] as const;
+/**
+ * Fixed mode shortcuts use `event.code` (physical key) instead of `event.key`
+ * because Shift changes the key value on many layouts
+ * (e.g. Shift+1 = "!" on US, Shift+0 = ")" etc.).
+ */
+const FIXED_MODE_SHORTCUTS: ReadonlyArray<{ code: string; mode: ModeId }> = [
+  { code: "Digit0", mode: MODES.off },
+  { code: "Digit1", mode: MODES.auto },
+  { code: "Digit2", mode: MODES.autoOff },
+  { code: "Digit3", mode: MODES.pushToTalk },
+];
 
 export function parseShortcut(shortcut: string) {
   const parts = shortcut.toLowerCase().split("+");
@@ -69,7 +74,8 @@ export function shouldHandleShortcutKeyDown({
 
 export function getFixedModeShortcutTarget(event: ShortcutKeyDownEvent): ModeId | null {
   if (event.repeat) return null;
-  const match = FIXED_MODE_SHORTCUTS.find(({ shortcut }) => matchesShortcut(event, shortcut));
+  if (!event.ctrlKey || !event.shiftKey || event.altKey || event.metaKey) return null;
+  const match = FIXED_MODE_SHORTCUTS.find(({ code }) => event.code === code);
   return match?.mode ?? null;
 }
 


### PR DESCRIPTION
## Summary
- Fixed mode shortcuts (`Ctrl+Shift+0/1/2/3`) not working due to `event.key` being modified by Shift on most keyboard layouts (e.g. `Shift+1` = `!`). Now uses `event.code` (physical key: `Digit0`-`Digit3`) which is layout-independent.
- Fixed mic toggle shortcut (`Ctrl+Shift+M`) unintentionally restoring `lastActiveMode` when pressed in Off mode. Now the shortcut only operates within the current mode without switching it.

## Test plan
- [x] 154 unit tests passing
- [ ] Test on Meet tab: `Ctrl+Shift+1/2/3` switches modes correctly
- [ ] Test on Meet tab: `Ctrl+Shift+0` switches to Off
- [ ] Test `Ctrl+Shift+M` in Off mode — should NOT change mode to Auto
- [ ] Test `Ctrl+Shift+M` in Auto mode — should toggle mute without changing mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated keyboard event handling tests to improve shortcut detection reliability.

* **Refactor**
  * Enhanced keyboard shortcut detection mechanism for improved accuracy.
  * Refined shortcut handler behavior to better manage inactive states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->